### PR TITLE
Kinda fixed the instance recognition regex

### DIFF
--- a/public/options.html
+++ b/public/options.html
@@ -23,7 +23,7 @@
 <body>
 <label for="instance">Lemmy instance:</label>
 <input type="text" id="instance" name="instance" placeholder="lemmy.world" required
-    pattern="^[a-zA-Z0-9\-ßàÁâãóôþüúðæåïçèõöÿýòäœêëìíøùîûñé]{1,63}\.[a-zA-Z]{2,63}$">
+    pattern="^([a-zA-Z0-9\-ßàÁâãóôþüúðæåïçèõöÿýòäœêëìíøùîûñé]{1,63}\.)+[a-zA-Z]{2,63}$">
 
 <div class="spacer"></div>
 


### PR DESCRIPTION
The old regex disallowed tons of valid instances.
I’m not sure the weird special character listing is required instead of using `\w-`, but I left that as is.